### PR TITLE
Compilation fixes for newer gcc/toolchains

### DIFF
--- a/cr3-kindle/src/device/device.h
+++ b/cr3-kindle/src/device/device.h
@@ -1,6 +1,8 @@
 #ifndef DEVICE_H
 #define DEVICE_H
 
+#include <unistd.h>
+
 #include <QProcess>
 #include <QDebug>
 #include <QWSServer>

--- a/cr3-kindle/src/mainwindow.h
+++ b/cr3-kindle/src/mainwindow.h
@@ -1,6 +1,7 @@
 #ifndef MAINWINDOW_H
 #define MAINWINDOW_H
 
+#include <unistd.h>
 #include <sys/ioctl.h>
 #include <fcntl.h>
 #include <linux/fb.h>

--- a/drivers/KindleFiveWay/kindlefiveway.h
+++ b/drivers/KindleFiveWay/kindlefiveway.h
@@ -13,6 +13,8 @@
 #ifndef KINDLEFIVEWAY_H
 #define KINDLEFIVEWAY_H
 
+#include <unistd.h>
+
 #include <QWSMouseHandler>
 #include <QSocketNotifier>
 


### PR DESCRIPTION
Some more compilation fixes for newer GCC/Ubuntu.

With these I'm able to  fully build CR3 with the latest GCC (CodeSourcery toolchain as well as a custom-built via crosstool-ng).
