### PR TITLE
Provide a natural way to hide the man menu, via Menu button itself

### DIFF
--- a/cr3-kindle/src/mainwindow.cpp
+++ b/cr3-kindle/src/mainwindow.cpp
@@ -319,6 +319,9 @@ void MainWindow::contextMenu( QPoint pos )
     menu->addAction(ui->actionAddBookmark);
     menu->addAction(ui->actionHide);
     menu->addAction(ui->actionClose);
+
+    new QShortcut(Qt::Key_Menu, menu, SLOT(hide()));
+
     menuActive = true;
     menu->exec(ui->view->mapToGlobal(pos));
     menuActive = false;

--- a/cr3-kindle/src/mainwindow.h
+++ b/cr3-kindle/src/mainwindow.h
@@ -18,6 +18,7 @@
 #include <QClipboard>
 #include <QWSServer>
 #include <QTimer>
+#include <QShortcut>
 
 #include <device.h>
 


### PR DESCRIPTION
This has been bothering me for a while.

New users find it confusing as well, when they press Menu to open the main menu but they couldn't actually hide it by pressing menu again. Users expect that the second Menu click will hide the menu since Kindle's stock UI works that way.
